### PR TITLE
enabled tab navigation

### DIFF
--- a/new.html
+++ b/new.html
@@ -41,11 +41,11 @@
 
 
           <section data-content="home" id="tab-content">
-            <a href="#about" alt="About William" data-content="about"></a><img src="img/profile.png" alt="about" class="headshot">
+            <a href="#about" alt="About William" data-content="about"><img src="img/profile.png" alt="about" class="headshot"></a>
 
-            <nav class"main-nav">
+            <nav class="main-nav">
 
-              <ul class"">
+              <ul class="">
                <li class="nav-menu-item tab" data-content="home"><a href="#" class="icon-home">HOME</a></li>
                <li class="nav-menu-item tab" data-content="portfolio"><a href="#" class="icon-books">PORTFOLIO</a></li>
                <li class="nav-menu-item tab" data-content="resume"><a href="#"class="icon-earth">RESUME</a></li>

--- a/scripts/portfolioView.js
+++ b/scripts/portfolioView.js
@@ -2,16 +2,63 @@
 var articleView = {};
 
 articleView.handleMainNav = function () {
-  $('.main-nav').on('click', '.tab', function() {
-    $('.tab').show();
+  //
+  $('li[data-content="home"]').on('click', function(){
+  // $('.main-nav').on('click', '.tab', function() {
+  //   $('.tab').show();
+  //   $(this).hide();
+  //   console.log('this.attr ', $(this).attr());
+    // $('.tab').show();
+    // $(this).hide();
+
+    // var content = $(this).attr('data-content');
+    //
+    // $('.tab-content').hide();
+    // $('#' + content).fadeIn(3000);
+
+    // show the whole nav bar but hide the tab for the current tab
+    $(this).parent().find($('li')).show();
     $(this).hide();
-
-    var content = $(this).attr('data-content');
-
-    $('.tab-content').hide();
-    $('#' + content).fadeIn(3000);
+    // hide all the content not corresponding to the tab
+    $('#about').hide();
+    $('#portfolio').hide();
+    $('#resume').hide();
+    $('#contact').hide();
+    $('#home').show();
   });
 
-  $('.main-nav .tab:first').click();
+  $('li[data-content="about"]').on('click', function(){
+    $(this).parent().find($('li')).show();
+    $(this).hide();
+    $('#portfolio').hide();
+    $('#resume').hide();
+    $('#contact').hide();
+    $('#about').show();
+  });
+  $('li[data-content="portfolio"]').on('click', function(){
+    $(this).parent().find($('li')).show();
+    $(this).hide();
+    $('#about').hide();
+    $('#resume').hide();
+    $('#contact').hide();
+    $('#portfolio').show();
+  });
+  $('li[data-content="resume"]').on('click', function(){
+    $(this).parent().find($('li')).show();
+    $(this).hide();
+    $('#about').hide();
+    $('#portfolio').hide();
+    $('#contact').hide();
+    $('#resume').show();
+  });
+  $('li[data-content="contact"]').on('click', function(){
+    $(this).parent().find($('li')).show();
+    $(this).hide();
+    $('#about').hide();
+    $('#portfolio').hide();
+    $('#resume').hide();
+    $('#contact').show();
+  });
+  //$('.main-nav .tab:first').click();
 };
 articleView.handleMainNav();


### PR DESCRIPTION
The work was mainly done in portfolioView.js

The main part was working with the nav bar to show the right content after a nav list item was clicked. At the same time the unrelated content was to be hidden. With hard coding we were able to select where the content was located in the html and show or hide each element. This developed some similar, repetitive patterns that can later be made more efficient.

The dynamic feature we enabled was looking at the node of that same clicked tab, walking up the tree to the parent, showing all the children, and hiding the clicked child. Visually, this hid the tab that was clicked and made it reappear if you navigated to another tab.